### PR TITLE
Adds missing dependecy for Xdebug 3.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ FROM php:8.1-cli-alpine
 RUN apk update && apk add --no-cache \
     $PHPIZE_DEPS \
     git \
-    bash
+    bash \
+    linux-headers
 
 # Xdebug
-RUN pecl install xdebug
+RUN pecl install xdebug-3.2.1
 RUN docker-php-ext-enable xdebug
 
 # Composer


### PR DESCRIPTION
  Pecl automatically installs latest version of xdebug which from version 3.2.x requires `linux-headers` as dependency.
  Locked Xdebug version prevents possible future breakups. 