### PR TITLE
Change of numeric formatting, Upgrade of slevomat coding standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "slevomat/coding-standard": "8.7.*",
+        "slevomat/coding-standard": "8.8.*",
         "squizlabs/php_codesniffer": "3.7.*"
     }
 }

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -31,7 +31,7 @@
 
     <!--  Numbers  -->
     <rule ref="SlevomatCodingStandard.Numbers">
-        <exclude name="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator"/>
+        <exclude name="SlevomatCodingStandard.Numbers.DisallowNumericLiteralSeparator.DisallowedNumericLiteralSeparator"/>
     </rule>
 
     <!--  Exceptions  -->


### PR DESCRIPTION
1. Change of numeric formatting rule from classic to number with literal separator (https://wiki.php.net/rfc/numeric_literal_separator)
2. Upgrade of slevomat coding standards from 8.7 to 8.8