### PR TITLE
Update InlineDocCommentDeclaration rule

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -206,7 +206,11 @@
             </property>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration">
+        <properties>
+            <property name="allowDocCommentAboveReturn" value="true"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
 


### PR DESCRIPTION
Add property to allow doc comments without variable name above return statements.