### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 ### Changed
-- Updated Slevomat Coding Standard to 8.20.*
+- Updated Slevomat Coding Standard to 8.23.*
+- Updated PHP_CodeSniffer to 4.0.*
 
 ## [0.3.0] - 2025-06-19
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     ],
     "require": {
         "php": ">=7.4",
-        "slevomat/coding-standard": "8.20.*",
-        "squizlabs/php_codesniffer": "3.13.*"
+        "slevomat/coding-standard": "8.23.*",
+        "squizlabs/php_codesniffer": "4.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
## Summary
- Upgrade Slevomat Coding Standard from 8.20.* to 8.23.*  
- Upgrade PHP_CodeSniffer from 3.13.* to 4.0.*

## Test plan
- [ ] Run `composer install` to install new dependencies
- [ ] Run `composer test` to ensure all tests pass
- [ ] Run `composer cs-check` to verify coding standards still work correctly
- [ ] Verify compatibility with existing ruleset configurations

🤖 Generated with [Claude Code](https://claude.ai/code)