### PR TITLE
Upgrade slevomat/coding-standard to 8.29.* and add three new sniffs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "slevomat/coding-standard": "8.27.*",
+        "slevomat/coding-standard": "8.29.*",
         "squizlabs/php_codesniffer": "4.0.*"
     },
     "require-dev": {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -40,6 +40,7 @@
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
 
     <!--  Exceptions  -->
+    <rule ref="SlevomatCodingStandard.Exceptions.CatchExceptionsOrder"/>
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
     <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
@@ -104,6 +105,7 @@
     <rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseOrder"/>
     <rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition"/>
     <rule ref="SlevomatCodingStandard.Classes.ParentCallSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
@@ -194,6 +196,7 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder"/>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
         <properties>
             <property name="forbiddenAnnotations" type="array">


### PR DESCRIPTION
## Summary
- Bump `slevomat/coding-standard` from `8.27.*` to `8.29.*` (latest 8.29.0)
- Enable the three sniffs introduced in slevomat 8.28.0:
  - `SlevomatCodingStandard.Exceptions.CatchExceptionsOrder`
  - `SlevomatCodingStandard.Classes.TraitUseOrder`
  - `SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder`

`squizlabs/php_codesniffer` (`4.0.*`) and `phpunit` already cover their latest releases — no change needed.

## Verification
Verified in a Docker container (`dockette/php:8.3`, PHP 8.3.29, Composer 2.9.2):
- `composer install` — slevomat `8.29.0` + php_codesniffer `4.0.1` install cleanly
- `composer cs-check` — passes clean (ruleset parses, so the new sniff names are valid)
- `composer test` — `OK (18 tests, 46 assertions)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)